### PR TITLE
Add request and notification message creators that handle param wrapping

### DIFF
--- a/scala-json-rpc/src/main/scala/com/dhpcs/jsonrpc/JsonRpcMessage.scala
+++ b/scala-json-rpc/src/main/scala/com/dhpcs/jsonrpc/JsonRpcMessage.scala
@@ -119,6 +119,13 @@ object JsonRpcMessage {
 final case class JsonRpcRequestMessage(method: String, params: Params, id: CorrelationId) extends JsonRpcMessage
 
 object JsonRpcRequestMessage {
+
+  def apply(method: String, params: JsObject, id: CorrelationId): JsonRpcRequestMessage =
+    JsonRpcRequestMessage(method, ObjectParams(params), id)
+
+  def apply(method: String, params: JsArray, id: CorrelationId): JsonRpcRequestMessage =
+    JsonRpcRequestMessage(method, ArrayParams(params), id)
+
   implicit final val JsonRpcRequestMessageFormat: Format[JsonRpcRequestMessage] = (
     (__ \ "jsonrpc").format(verifying[String](_ == JsonRpcMessage.Version)) and
       (__ \ "method").format[String] and
@@ -335,6 +342,13 @@ object JsonRpcResponseMessageBatch {
 final case class JsonRpcNotificationMessage(method: String, params: Params) extends JsonRpcMessage
 
 object JsonRpcNotificationMessage {
+
+  def apply(method: String, params: JsObject): JsonRpcNotificationMessage =
+    JsonRpcNotificationMessage(method, ObjectParams(params))
+
+  def apply(method: String, params: JsArray): JsonRpcNotificationMessage =
+    JsonRpcNotificationMessage(method, ArrayParams(params))
+
   implicit final val JsonRpcNotificationMessageFormat: Format[JsonRpcNotificationMessage] = (
     (__ \ "jsonrpc").format(verifying[String](_ == JsonRpcMessage.Version)) and
       (__ \ "method").format[String] and

--- a/scala-json-rpc/src/main/scala/com/dhpcs/jsonrpc/MessageCompanions.scala
+++ b/scala-json-rpc/src/main/scala/com/dhpcs/jsonrpc/MessageCompanions.scala
@@ -32,7 +32,7 @@ trait CommandCompanion[A] {
     val (method, writes) =
       classWrites.getOrElse(command.getClass, sys.error(s"No format found for ${command.getClass}"))
     val bWrites = writes.asInstanceOf[OWrites[B]]
-    JsonRpcRequestMessage(method, ObjectParams(bWrites.writes(command)), id)
+    JsonRpcRequestMessage(method, bWrites.writes(command), id)
   }
 }
 
@@ -83,7 +83,7 @@ trait NotificationCompanion[A] {
     val (method, writes) =
       classWrites.getOrElse(notification.getClass, sys.error(s"No format found for ${notification.getClass}"))
     val bWrites = writes.asInstanceOf[OWrites[B]]
-    JsonRpcNotificationMessage(method, ObjectParams(bWrites.writes(notification)))
+    JsonRpcNotificationMessage(method, bWrites.writes(notification))
   }
 }
 

--- a/scala-json-rpc/src/test/scala/com/dhpcs/jsonrpc/JsonRpcMessageSpec.scala
+++ b/scala-json-rpc/src/test/scala/com/dhpcs/jsonrpc/JsonRpcMessageSpec.scala
@@ -134,11 +134,10 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
       describe("and a null id") {
         implicit val jsonRpcRequestMessage = JsonRpcRequestMessage(
           method = "testMethod",
-          ArrayParams(
-            Json.arr(
-              JsString("param1"),
-              JsString("param2")
-            )),
+          Json.arr(
+            "param1",
+            "param2"
+          ),
           NoCorrelationId
         )
         implicit val jsonRpcRequestMessageJson = Json.parse(
@@ -156,11 +155,10 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
       describe("and a string id") {
         implicit val jsonRpcRequestMessage = JsonRpcRequestMessage(
           method = "testMethod",
-          ArrayParams(
-            Json.arr(
-              JsString("param1"),
-              JsString("param2")
-            )),
+          Json.arr(
+            "param1",
+            "param2"
+          ),
           StringCorrelationId("one")
         )
         implicit val jsonRpcRequestMessageJson = Json.parse(
@@ -178,11 +176,10 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
       describe("and a numeric id") {
         implicit val jsonRpcRequestMessage = JsonRpcRequestMessage(
           method = "testMethod",
-          ArrayParams(
-            Json.arr(
-              JsString("param1"),
-              JsString("param2")
-            )),
+          Json.arr(
+            "param1",
+            "param2"
+          ),
           NumericCorrelationId(1)
         )
         implicit val jsonRpcRequestMessageJson = Json.parse(
@@ -199,11 +196,10 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
         describe("with a fractional part") {
           implicit val jsonRpcRequestMessage = JsonRpcRequestMessage(
             method = "testMethod",
-            ArrayParams(
-              Json.arr(
-                JsString("param1"),
-                JsString("param2")
-              )),
+            Json.arr(
+              "param1",
+              "param2"
+            ),
             NumericCorrelationId(1.1)
           )
           implicit val jsonRpcRequestMessageJson = Json.parse(
@@ -223,11 +219,10 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
       describe("and a null id") {
         implicit val jsonRpcRequestMessage = JsonRpcRequestMessage(
           method = "testMethod",
-          ObjectParams(
-            Json.obj(
-              "param1" -> JsString("param1"),
-              "param2" -> JsString("param2")
-            )),
+          Json.obj(
+            "param1" -> "param1",
+            "param2" -> "param2"
+          ),
           NoCorrelationId
         )
         implicit val jsonRpcRequestMessageJson = Json.parse(
@@ -245,11 +240,10 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
       describe("and a string id") {
         implicit val jsonRpcRequestMessage = JsonRpcRequestMessage(
           method = "testMethod",
-          ObjectParams(
-            Json.obj(
-              "param1" -> JsString("param1"),
-              "param2" -> JsString("param2")
-            )),
+          Json.obj(
+            "param1" -> "param1",
+            "param2" -> "param2"
+          ),
           StringCorrelationId("one")
         )
         implicit val jsonRpcRequestMessageJson = Json.parse(
@@ -267,11 +261,9 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
       describe("and a numeric id") {
         implicit val jsonRpcRequestMessage = JsonRpcRequestMessage(
           method = "testMethod",
-          ObjectParams(
-            Json.obj(
-              "param1" -> JsString("param1"),
-              "param2" -> JsString("param2")
-            )
+          Json.obj(
+            "param1" -> "param1",
+            "param2" -> "param2"
           ),
           NumericCorrelationId(1)
         )
@@ -289,11 +281,9 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
         describe("with a fractional part") {
           implicit val jsonRpcRequestMessage = JsonRpcRequestMessage(
             method = "testMethod",
-            ObjectParams(
-              Json.obj(
-                "param1" -> JsString("param1"),
-                "param2" -> JsString("param2")
-              )
+            Json.obj(
+              "param1" -> "param1",
+              "param2" -> "param2"
             ),
             NumericCorrelationId(1.1)
           )
@@ -345,11 +335,9 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
           Right(
             JsonRpcRequestMessage(
               method = "testMethod",
-              ObjectParams(
-                Json.obj(
-                  "param1" -> JsString("param1"),
-                  "param2" -> JsString("param2")
-                )
+              Json.obj(
+                "param1" -> "param1",
+                "param2" -> "param2"
               ),
               NumericCorrelationId(1)
             ))
@@ -385,13 +373,13 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
       implicit val jsonRpcRequestMessageBatch = JsonRpcRequestMessageBatch(
         Seq(
           Left(
-            JsonRpcNotificationMessage(method = "testMethod",
-                                       ObjectParams(
-                                         Json.obj(
-                                           "param1" -> JsString("param1"),
-                                           "param2" -> JsString("param2")
-                                         )
-                                       ))
+            JsonRpcNotificationMessage(
+              method = "testMethod",
+              Json.obj(
+                "param1" -> "param1",
+                "param2" -> "param2"
+              )
+            )
           )
         )
       )
@@ -608,11 +596,9 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
     describe("with a result") {
       describe("and a null id") {
         implicit val jsonRpcResponseMessage = JsonRpcResponseSuccessMessage(
-          JsObject(
-            Seq(
-              "param1" -> JsString("param1"),
-              "param2" -> JsString("param2")
-            )
+          Json.obj(
+            "param1" -> "param1",
+            "param2" -> "param2"
           ),
           NoCorrelationId
         )
@@ -629,11 +615,9 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
       }
       describe("and a string id") {
         implicit val jsonRpcResponseMessage = JsonRpcResponseSuccessMessage(
-          JsObject(
-            Seq(
-              "param1" -> JsString("param1"),
-              "param2" -> JsString("param2")
-            )
+          Json.obj(
+            "param1" -> "param1",
+            "param2" -> "param2"
           ),
           StringCorrelationId("one")
         )
@@ -650,11 +634,9 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
       }
       describe("and a numeric id") {
         implicit val jsonRpcResponseMessage = JsonRpcResponseSuccessMessage(
-          JsObject(
-            Seq(
-              "param1" -> JsString("param1"),
-              "param2" -> JsString("param2")
-            )
+          Json.obj(
+            "param1" -> "param1",
+            "param2" -> "param2"
           ),
           NumericCorrelationId(1)
         )
@@ -670,11 +652,9 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
         it should behave like write
         describe("with a fractional part") {
           implicit val jsonRpcResponseMessage = JsonRpcResponseSuccessMessage(
-            JsObject(
-              Seq(
-                "param1" -> JsString("param1"),
-                "param2" -> JsString("param2")
-              )
+            Json.obj(
+              "param1" -> "param1",
+              "param2" -> "param2"
             ),
             NumericCorrelationId(1.1)
           )
@@ -722,11 +702,9 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
       implicit val jsonRpcResponseMessageBatch = JsonRpcResponseMessageBatch(
         Seq(
           JsonRpcResponseSuccessMessage(
-            JsObject(
-              Seq(
-                "param1" -> JsString("param1"),
-                "param2" -> JsString("param2")
-              )
+            Json.obj(
+              "param1" -> "param1",
+              "param2" -> "param2"
             ),
             NumericCorrelationId(1)
           )
@@ -842,11 +820,9 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
     describe("with a params array") {
       implicit val jsonRpcNotificationMessage = JsonRpcNotificationMessage(
         method = "testMethod",
-        ArrayParams(
-          Json.arr(
-            JsString("param1"),
-            JsString("param2")
-          )
+        Json.arr(
+          "param1",
+          "param2"
         )
       )
       implicit val jsonRpcNotificationMessageJson = Json.parse(
@@ -863,11 +839,9 @@ class JsonRpcMessageSpec extends FunSpec with FormatBehaviors[JsonRpcMessage] wi
     describe("with a params object") {
       implicit val jsonRpcNotificationMessage = JsonRpcNotificationMessage(
         method = "testMethod",
-        ObjectParams(
-          Json.obj(
-            "param1" -> JsString("param1"),
-            "param2" -> JsString("param2")
-          )
+        Json.obj(
+          "param1" -> "param1",
+          "param2" -> "param2"
         )
       )
       implicit val jsonRpcNotificationMessageJson = Json.parse(

--- a/scala-json-rpc/src/test/scala/com/dhpcs/jsonrpc/MessageCompanionsSpec.scala
+++ b/scala-json-rpc/src/test/scala/com/dhpcs/jsonrpc/MessageCompanionsSpec.scala
@@ -132,7 +132,7 @@ class MessageCompanionsSpec extends FunSpec with Matchers {
       it should behave like commandReadError(
         JsonRpcRequestMessage(
           method = "invalidMethod",
-          ObjectParams(Json.obj()),
+          Json.obj(),
           NumericCorrelationId(1)
         ),
         JsError("unknown method invalidMethod")
@@ -143,7 +143,7 @@ class MessageCompanionsSpec extends FunSpec with Matchers {
         it should behave like commandReadError(
           JsonRpcRequestMessage(
             method = "addTransaction",
-            ArrayParams(Json.arr()),
+            Json.arr(),
             NumericCorrelationId(1)
           ),
           JsError(__, "command parameters must be named")
@@ -153,7 +153,7 @@ class MessageCompanionsSpec extends FunSpec with Matchers {
         it should behave like commandReadError(
           JsonRpcRequestMessage(
             method = "addTransaction",
-            ObjectParams(Json.obj()),
+            Json.obj(),
             NumericCorrelationId(1)
           ),
           JsError(
@@ -179,15 +179,13 @@ class MessageCompanionsSpec extends FunSpec with Matchers {
       implicit val id = NumericCorrelationId(1)
       implicit val jsonRpcRequestMessage = JsonRpcRequestMessage(
         "addTransaction",
-        ObjectParams(
-          Json.obj(
-            "from"        -> 0,
-            "to"          -> 1,
-            "value"       -> BigDecimal(1000000),
-            "description" -> "Property purchase",
-            "metadata" -> Json.obj(
-              "property" -> "The TARDIS"
-            )
+        Json.obj(
+          "from"        -> 0,
+          "to"          -> 1,
+          "value"       -> BigDecimal(1000000),
+          "description" -> "Property purchase",
+          "metadata" -> Json.obj(
+            "property" -> "The TARDIS"
           )
         ),
         NumericCorrelationId(1)
@@ -220,7 +218,7 @@ class MessageCompanionsSpec extends FunSpec with Matchers {
       it should behave like notificationReadError(
         JsonRpcNotificationMessage(
           method = "invalidMethod",
-          ObjectParams(Json.obj())
+          Json.obj()
         ),
         JsError("unknown method invalidMethod")
       )
@@ -230,7 +228,7 @@ class MessageCompanionsSpec extends FunSpec with Matchers {
         it should behave like notificationReadError(
           JsonRpcNotificationMessage(
             method = "transactionAdded",
-            ArrayParams(Json.arr())
+            Json.arr()
           ),
           JsError(__, "notification parameters must be named")
         )
@@ -239,7 +237,7 @@ class MessageCompanionsSpec extends FunSpec with Matchers {
         it should behave like notificationReadError(
           JsonRpcNotificationMessage(
             method = "transactionAdded",
-            ObjectParams(Json.obj())
+            Json.obj()
           ),
           JsError(__ \ "transaction", "error.path.missing")
         )
@@ -254,10 +252,8 @@ class MessageCompanionsSpec extends FunSpec with Matchers {
       )
       implicit val jsonRpcNotificationMessage = JsonRpcNotificationMessage(
         method = "transactionAdded",
-        params = ObjectParams(
-          Json.obj(
-            "transaction" -> Json.parse("""{"from":0,"to":1,"value":1000000,"created":1434115187612}""")
-          )
+        params = Json.obj(
+          "transaction" -> Json.parse("""{"from":0,"to":1,"value":1000000,"created":1434115187612}""")
         )
       )
       it should behave like notificationRead


### PR DESCRIPTION
This allows calling code to be a little less verbose (as the updated tests
show).

Also simplify the construction of some existng test value (JsObject(Seq()) ->
Json.obj(), and JsString() -> _).