### PR TITLE
Replace Either[..Notification.., ..Request..] with ..RequestOrNotific…

### DIFF
--- a/scala-json-rpc/src/test/scala/com/dhpcs/jsonrpc/JsonRpcMessageSpec.scala
+++ b/scala-json-rpc/src/test/scala/com/dhpcs/jsonrpc/JsonRpcMessageSpec.scala
@@ -381,16 +381,14 @@ class JsonRpcMessageSpec extends FreeSpec with Matchers {
     "with a single request" - {
       val jsonRpcRequestMessageBatch = JsonRpcRequestMessageBatch(
         Seq(
-          Right(
-            JsonRpcRequestMessage(
-              method = "testMethod",
-              Json.obj(
-                "param1" -> "param1",
-                "param2" -> "param2"
-              ),
-              NumericCorrelationId(1)
-            ))
-        )
+          JsonRpcRequestMessage(
+            method = "testMethod",
+            Json.obj(
+              "param1" -> "param1",
+              "param2" -> "param2"
+            ),
+            NumericCorrelationId(1)
+          ))
       )
       val jsonRpcRequestMessageBatchJson = Json.parse(
         """[
@@ -426,13 +424,11 @@ class JsonRpcMessageSpec extends FreeSpec with Matchers {
     "with a single notification" - {
       val jsonRpcRequestMessageBatch = JsonRpcRequestMessageBatch(
         Seq(
-          Left(
-            JsonRpcNotificationMessage(
-              method = "testMethod",
-              Json.obj(
-                "param1" -> "param1",
-                "param2" -> "param2"
-              )
+          JsonRpcNotificationMessage(
+            method = "testMethod",
+            Json.obj(
+              "param1" -> "param1",
+              "param2" -> "param2"
             )
           )
         )


### PR DESCRIPTION
…ation..

This eliminates the need to wrap with Right or Left during construction, as the
change in the spec shows, and removes the need to extract during matching.

It also triggers the removal of eitherValueFormat which is now no longer used
(and can be removed even though public because 2.0.0 has not yet been released).
eitherObjectFormat is also removed because it is no longer used as of 4aa65.